### PR TITLE
closed #45 windowsのショートカット変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "AutoBacket",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Thunderbird auto classification web extension",
   "author": "A-tak <hoge+git@a-tak.com>",
   "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -16,12 +16,7 @@
     }
   },
   "default_locale": "en",
-  "permissions": [
-    "messagesRead",
-    "menus",
-    "storage",
-    "accountsRead"
-    ],
+  "permissions": ["messagesRead", "menus", "storage", "accountsRead"],
   "browser_action": {
     "default_title": "AutoBacket",
     "default_popup": "popup/popup.html"
@@ -33,18 +28,18 @@
     "page": "options/options.html",
     "chrome_style": true,
     "open_in_tab": false
-  },  
+  },
   "commands": {
     "all-classificate": {
-      "suggested_key": { "default": "Alt+Shift+A" },
+      "suggested_key": { "default": "Alt+Shift+B", "windows": "Ctrl+B" },
       "description": "__MSG_allClassificateDescription__"
     },
     "classificate": {
-      "suggested_key": { "default": "Alt+Shift+C" },
+      "suggested_key": { "default": "Alt+Shift+C", "windows": "Ctrl+Shift+C" },
       "description": "__MSG_classificateDescription__"
     },
     "view-log": {
-      "suggested_key": { "default": "Alt+Shift+V" },
+      "suggested_key": { "default": "Alt+Shift+V", "windows": "Ctrl+Shift+V" },
       "description": "__MSG_viewLogDescription__"
     }
   }


### PR DESCRIPTION
Windowsだとaltをショートカットキーに使うとメニューと競合するのでctrlキーのショートカットに変更。
一括判定はctrl + Bに変更(その他プラットフォームはalt + shift +B)